### PR TITLE
修复无法滚动到底部的问题

### DIFF
--- a/src/app/alpha/message/message.component.ts
+++ b/src/app/alpha/message/message.component.ts
@@ -36,7 +36,7 @@ export class MessageComponent implements OnInit {
       return '';
     }
   }
-  ngAfterContentInit(){
+  ngAfterViewInit(){
     console.log('dom modi');
     //if (!isPlatformBrowser(this.plat)) {
       //return;

--- a/src/app/alpha/paid-message/paid-message.component.ts
+++ b/src/app/alpha/paid-message/paid-message.component.ts
@@ -32,7 +32,7 @@ export class LegacyPaidMessageComponent implements OnInit {
       return '#00b8d4'; // 50
     }
   }
-  ngAfterContentInit(){
+  ngAfterViewInit(){
     console.log('dom modi');
     //if (!isPlatformBrowser(this.plat)) {
       //return;


### PR DESCRIPTION
当弹幕过长产生换行时，无法准确滚动到底部，造成最后一条弹幕被遮挡的问题。

解决方案：使用 `ngAfterViewInit` 代替 `ngAfterContentInit`

修复前：

![114514](https://user-images.githubusercontent.com/4951333/54815306-a2360780-4ccc-11e9-90ff-4aa3ffd8c2b4.png)

![114514](https://user-images.githubusercontent.com/4951333/54815527-2ee0c580-4ccd-11e9-88a0-ae2f0bfbc2b9.jpg)

（名字经打码处理）

修复后：

![114514](https://user-images.githubusercontent.com/4951333/54815331-b1b55080-4ccc-11e9-9ad0-e5d71bd912e9.png)

