### PR TITLE
Update wordFilter

### DIFF
--- a/src/app/message-processor.service.ts
+++ b/src/app/message-processor.service.ts
@@ -33,7 +33,8 @@ export class MessageProcessorService {
     '梗',
     '傻逼', '弱智', '脑残', '屏蔽', 'cnm',
     '警察', '加群', '群号', 'QQ群', '出警',
-    '人工智能', '老婆'
+    '人工智能', '老婆',
+    '\0'
   ];
 
   blackList: Array<number> = [];


### PR DESCRIPTION
更新 wordFilter 规则拦截脚本哥

按照之前的日志分析脚本哥的脚本弹幕均以 `\0` 结尾，添加此规则过滤

（但如果脚本哥更新了他的脚本可能就失效了～）