### PR TITLE
新接口的支持

### DIFF
--- a/bilichat.js
+++ b/bilichat.js
@@ -37,6 +37,18 @@ app.get('/api/avatar/:userid', (req, res) => {
     })
 })
 
+app.get('/api/room_config/:roomid', (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Content-Type', 'application/json;charset=utf-8');
+    request('https://api.live.bilibili.com/room/v1/Danmu/getConf?room_id=' + req.params.roomid, { json: true }, (error, response, body) => {
+      if (!error && response.statusCode == 200) {
+        res.send(body)
+      } else {
+        res.sendStatus(403)
+      }
+    })
+  })
+  
 app.get('/api/stat/:roomid', (req, res) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Content-Type', 'application/json;charset=utf-8');

--- a/server.ts
+++ b/server.ts
@@ -74,6 +74,18 @@ app.get('/api/avatar/:userid', (req, res) => {
   })
 });
 
+app.get('/api/room_config/:roomid', (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Content-Type', 'application/json;charset=utf-8');
+  request('https://api.live.bilibili.com/room/v1/Danmu/getConf?room_id=' + req.params.roomid, { json: true }, (error, response, body) => {
+    if (!error && response.statusCode == 200) {
+      res.send(body)
+    } else {
+      res.sendStatus(403)
+    }
+  })
+})
+
 app.get('/api/stat/:roomid', (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'application/json;charset=utf-8');

--- a/src/app/biliws.service.ts
+++ b/src/app/biliws.service.ts
@@ -53,8 +53,8 @@ export class BiliwsService {
     private proc: MessageProcessorService) {
   }
 
-  connect(roomid: number): Observable<IMessage> {
-    this.ws = new WebSocket('wss://broadcastlv.chat.bilibili.com/sub');
+  connect(roomid: number, danmu_host: string, token: string): Observable<IMessage> {
+    this.ws = new WebSocket('wss://' + danmu_host + '/sub');
     this.ws.binaryType = 'arraybuffer';
     return new Observable(
       observer => {
@@ -64,7 +64,8 @@ export class BiliwsService {
             roomid: Number(roomid),
             protover: 2,
             platform: 'web',
-            clientver: '1.5.15'
+            clientver: '1.5.15',
+            key: token
           };
           this.sendPackageObj(7, obj);
           this.heartbeatHandler = setInterval(() => { this.sendHeartbeat(); }, 30000);


### PR DESCRIPTION
增加了对新接口的支持，即从 https://api.live.bilibili.com/room/v1/Danmu/getConf?room_id= 中获取token和弹幕服务器列表来连接弹幕。（ broadcastlv.chat.bilibili.com 已经开始有单ip连接数限制了的样子）
目前仅在以下两个情况下测试并没发现问题：
1. npm run start 本地运行
2. npm run build:ssr 并 npm run serve:ssr 于不同公网ip的另一台机器上运行

不确定该api获取的token的有效期以及频率过高是否会导致b站的api返回4xx错误
可能写的不太好请多包涵